### PR TITLE
Revert "KnowType fix"

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -140,11 +140,7 @@ const char* CInv::GetCommand() const
 
 std::string CInv::ToString() const
 {
-     if(IsKnownType())
-         return strprintf("%s %s", GetCommand(), hash.ToString().c_str());
-     else
-         return strprintf("type=%d %s", type, hash.ToString().c_str());
-//    return strprintf("%s %s", GetCommand(), hash.ToString().substr(0,20).c_str());
+    return strprintf("%s %s", GetCommand(), hash.ToString().substr(0,20).c_str());
 }
 
 void CInv::print() const


### PR DESCRIPTION
Reverts DigitalPandacoin/pandacoin#13
substr(0,20).c_str());  was in pandacoin,  we need to keep it that way.